### PR TITLE
fix: pin form-data >=4.0.6 to patch CRLF injection 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,10 @@
     "@openapitools/openapi-generator-cli": "2.39.1",
     "typescript": "^4.0 || ^5.0"
   },
-  "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c"
+  "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c",
+  "pnpm": {
+    "overrides": {
+      "form-data": ">=4.0.6"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,5 @@
+# Copyright IBM Corp. 2025, 2026
+
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data: '>=4.0.6'
+
 importers:
 
   .:
@@ -309,8 +312,8 @@ packages:
       debug:
         optional: true
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs-extra@11.3.6:
@@ -363,8 +366,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   http-proxy-agent@9.1.0:
@@ -767,7 +770,7 @@ snapshots:
   axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -883,7 +886,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   escalade@3.2.0: {}
 
@@ -920,12 +923,12 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fs-extra@11.3.6:
@@ -950,7 +953,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -984,7 +987,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.3:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 


### PR DESCRIPTION
## Summary

Adds a `pnpm.overrides` entry to force `form-data` to `>=4.0.6`, resolving a CRLF injection vulnerability in all resolved instances of the package.

- Advisory: [GHSA-hmw2-7cc7-3qxx](https://osv.dev/vulnerability/GHSA-hmw2-7cc7-3qxx)
- Jira: SECVULN-46679

### Root cause

`form-data` through v4.0.5 concatenated the `field` name and `filename` option directly into the `Content-Disposition` header with no escaping of `\r`, `\n`, or `"`. An application passing untrusted input as a field name or filename could allow an attacker to inject headers or smuggle additional multipart parts. Fixed in `form-data@4.0.6` by percent-encoding those characters, matching the WHATWG HTML `multipart/form-data` encoding algorithm.

### Transitive dependency chain

```
@openapitools/openapi-generator-cli
  └─ @nestjs/axios
       └─ axios
            └─ form-data 4.0.5 (vulnerable) → 4.0.6 (patched) ✅
```

### Why `pnpm.overrides` is necessary

`form-data` is two hops deep under `axios`, which is itself a transitive dependency. Upgrading `@openapitools/openapi-generator-cli` (done in the base PR #64) did not change the `axios` version or its `form-data` specifier. There is no direct dependency to upgrade through; `pnpm.overrides` is the pnpm-idiomatic mechanism for exactly this scenario.

### Scope

This repo never imports `form-data` directly — it is only present as a transitive dev dependency. There is no production exposure.

### Stacked on

This PR is stacked on top of #64. Once #64 merges, this PR's base can be retargeted to `main` and the diff will show only the `pnpm.overrides` addition.

### Files changed

- `package.json` — adds `pnpm.overrides` block (3 lines)
- `pnpm-lock.yaml` — regenerated; `form-data@4.0.5` replaced by `form-data@4.0.6` throughout

### Revert plan

Reverting this PR fully restores the previous state. No database migrations, feature flags, or infrastructure changes are involved.

---

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

  This PR is a security control improvement: it pins a transitive dev dependency to its patched version, eliminating a known CRLF injection vulnerability (GHSA-hmw2-7cc7-3qxx / SECVULN-46679) from the dependency graph.