### PR TITLE
fix: bump brace-expansion and shell-quote via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,5 @@
     "@openapitools/openapi-generator-cli": "2.39.1",
     "typescript": "^4.0 || ^5.0"
   },
-  "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c",
-  "pnpm": {
-    "overrides": {
-      "form-data": ">=4.0.6",
-      "brace-expansion": ">=5.0.7",
-      "shell-quote": ">=1.9.0"
-    }
-  }
+  "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c"
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c",
   "pnpm": {
     "overrides": {
-      "form-data": ">=4.0.6"
+      "form-data": ">=4.0.6",
+      "brace-expansion": ">=5.0.7",
+      "shell-quote": ">=1.9.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,5 @@
+# Copyright IBM Corp. 2025, 2026
+
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,3 @@
-# Copyright IBM Corp. 2025, 2026
-
 lockfileVersion: '9.0'
 
 settings:
@@ -8,6 +6,8 @@ settings:
 
 overrides:
   form-data: '>=4.0.6'
+  brace-expansion: '>=5.0.7'
+  shell-quote: '>=1.9.0'
 
 importers:
 
@@ -151,8 +151,8 @@ packages:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   call-bind-apply-helpers@1.0.2:
@@ -501,8 +501,8 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   signal-exit@4.1.0:
@@ -783,7 +783,7 @@ snapshots:
 
   basic-ftp@5.3.1: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -830,7 +830,7 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       supports-color: 10.2.2
       tree-kill: 1.2.2
       yargs: 18.0.0
@@ -1048,7 +1048,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minipass@7.1.3: {}
 
@@ -1117,7 +1117,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   signal-exit@4.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+overrides:
+  form-data: ">=4.0.6"
+  brace-expansion: ">=5.0.7"
+  shell-quote: ">=1.9.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+# Copyright IBM Corp. 2025, 2026
+
 overrides:
   form-data: ">=4.0.6"
   brace-expansion: ">=5.0.7"


### PR DESCRIPTION
## Summary

Adds `pnpm.overrides` to force patched versions of two transitive dev-only
dependencies pulled in by `@openapitools/openapi-generator-cli`:

| Package | Before | After | Advisory |
|---------|--------|-------|---------|
| `brace-expansion` | 5.0.6 | 5.0.7 | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) |
| `shell-quote` | 1.8.4 | 1.10.0 | [GHSA-395f-4hp3-45gv](https://github.com/advisories/GHSA-395f-4hp3-45gv) |

- Jira: SECVULN-50771 (brace-expansion), SECVULN-50770 (shell-quote)

### Root cause

**brace-expansion (GHSA-3jxr-9vmj-r5cp):** `expand()` exhibited exponential-time O(2ⁿ) behavior on consecutive non-expanding `{}` groups. A ~90-byte input of 30 groups blocked the event loop for ~2 minutes. Fixed in 5.0.7.

**shell-quote (GHSA-395f-4hp3-45gv):** `parse()` used `Array.prototype.concat` in a `reduce`, copying the entire growing array on each iteration — O(n²) complexity. A ~63 KB input froze the event loop for ~4.5 s, stalling all concurrent clients. Fixed in 1.9.0.

### Transitive dependency chains

```
brace-expansion (SECVULN-50771):
@openapitools/openapi-generator-cli@2.39.1
  └─ glob@13.0.6
       └─ minimatch@10.2.5
            └─ brace-expansion 5.0.6 (vulnerable) → 5.0.7 (patched) ✅

shell-quote (SECVULN-50770):
@openapitools/openapi-generator-cli@2.39.1
  └─ concurrently@10.0.3
       └─ shell-quote 1.8.4 (vulnerable) → 1.10.0 (patched) ✅
```

### Scope

Both packages are **transitive dev dependencies only**. They are never imported in production source code. There is zero production exposure.

No organic parent upgrade was available: `concurrently@10.0.3` still pins `shell-quote@1.8.4` and the latest `@openapitools` release ships the same dep tree. `pnpm.overrides` are used as last resort.

### Files changed

- `package.json` — added `brace-expansion: >=5.0.7` and `shell-quote: >=1.9.0` to `pnpm.overrides`
- `pnpm-lock.yaml` — regenerated lockfile reflecting patched versions

### Revert plan

Reverting this PR fully restores the previous state. No migrations, feature flags, or infrastructure changes are involved.

---

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  This PR is a security control improvement: it upgrades two transitive dev dependencies to their patched versions, eliminating known DoS vulnerabilities (GHSA-3jxr-9vmj-r5cp / SECVULN-50771 and GHSA-395f-4hp3-45gv / SECVULN-50770) from the dependency graph.